### PR TITLE
Paginate prompt response table queries with sort

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ curl -X POST http://127.0.0.1:5000/api/v1/openai/prompt -H "Content-Type: applic
 and
 
 ```
-curl http://127.0.0.1:5000/api/v1/openai/prompts -H "Content-Type: application/json"
+curl http://127.0.0.1:5000/api/v1/openai/prompt-responses -H "Content-Type: application/json"
 ```
 
 ## Deployment

--- a/app/controllers/__init__.py
+++ b/app/controllers/__init__.py
@@ -1,1 +1,1 @@
-from .prompts import create_new_prompt_response, get_all_prompt_responses
+from .prompts import create_new_prompt_response, query_prompt_responses

--- a/app/controllers/prompts.py
+++ b/app/controllers/prompts.py
@@ -50,7 +50,7 @@ def query_prompt_responses(request):
 
         return (
             jsonify(
-                PromptResponseService.get_all_prompt_responses(
+                PromptResponseService.query_prompt_responses(
                     page, per_page, sort_by, sort_order
                 )
             ),

--- a/app/controllers/prompts.py
+++ b/app/controllers/prompts.py
@@ -1,7 +1,6 @@
 from flask import jsonify
 import openai
 from app.services import PromptResponseService
-import json
 
 
 def create_new_prompt_response(request):
@@ -33,8 +32,31 @@ def create_new_prompt_response(request):
         )
 
 
-def get_all_prompt_responses():
+def query_prompt_responses(request):
     try:
-        return jsonify(PromptResponseService.get_all_prompt_responses()), 200
+        # parse the args from the request
+        page = int(request.args.get("page", 1))
+        per_page = int(request.args.get("per_page", 10))
+        sort_by = request.args.get(
+            "sort_by", "created_at"
+        )  # Default sort by created_at
+        sort_order = request.args.get("sort_order", "asc")
+
+        if sort_by not in ["response_time", "created_at"]:
+            return jsonify({"error": "Invalid sort_by parameter"}), 400
+
+        if sort_order not in ["asc", "desc"]:
+            return jsonify({"error": "Invalid sort_order parameter"}), 400
+
+        return (
+            jsonify(
+                PromptResponseService.get_all_prompt_responses(
+                    page, per_page, sort_by, sort_order
+                )
+            ),
+            200,
+        )
+    except ValueError:
+        return jsonify({"error": "Page and per_page parameters must be integers"}), 400
     except Exception as e:
         return jsonify({"error": str(e)}), 400

--- a/app/models/prompt_response.py
+++ b/app/models/prompt_response.py
@@ -1,4 +1,3 @@
-import json
 from app.database import db
 from datetime import datetime
 from sqlalchemy.dialects.postgresql import JSONB

--- a/app/routes/openai.py
+++ b/app/routes/openai.py
@@ -1,5 +1,5 @@
 from flask import Blueprint, request, jsonify
-from app.controllers import create_new_prompt_response, get_all_prompt_responses
+from app.controllers import create_new_prompt_response, query_prompt_responses
 
 
 bp = Blueprint("openai", __name__)
@@ -12,4 +12,4 @@ def post_prompt():
 
 @bp.route("/prompt-responses", methods=["GET"])
 def get_prompt_responses():
-    return get_all_prompt_responses()
+    return query_prompt_responses(request)

--- a/app/services/prompt_response_service.py
+++ b/app/services/prompt_response_service.py
@@ -70,7 +70,7 @@ class PromptResponseService:
             ) from e
 
     @staticmethod
-    def get_all_prompt_responses():
+    def query_prompt_responses(page, per_page, sort_by, sort_order):
         """
         Retrieves all prompt responses from the database and returns them as a list of dictionaries.
 
@@ -84,9 +84,28 @@ class PromptResponseService:
         Raises:
         - RuntimeError: If there is an issue fetching the prompt responses from the database.
         """
+
         try:
-            prompt_responses = PromptResponse.query.all()
-            return [response.to_dict() for response in prompt_responses]
+            query = PromptResponse.query
+
+            if sort_order == "asc":
+                query = query.order_by(getattr(PromptResponse, sort_by).asc())
+            else:
+                query = query.order_by(getattr(PromptResponse, sort_by).desc())
+
+            paginated_responses = query.paginate(
+                page=page, per_page=per_page, error_out=False
+            )
+
+            items = [item.to_dict() for item in paginated_responses.items]
+
+            return {
+                "page": paginated_responses.page,
+                "per_page": paginated_responses.per_page,
+                "total_pages": paginated_responses.pages,
+                "total_items": paginated_responses.total,
+                "items": items,
+            }
         except Exception as e:
             raise RuntimeError(
                 f"Failed to fetch prompt responses from the database: {e}"

--- a/app/services/prompt_response_service.py
+++ b/app/services/prompt_response_service.py
@@ -1,7 +1,6 @@
 from flask import current_app
 import time
 from app.models import PromptResponse
-import json
 
 
 class PromptResponseService:


### PR DESCRIPTION
# Changelog
- Paginating request to the PromptResponse table
  - validations for the request arguments
  - endpoint now returns counts and items 